### PR TITLE
Added additional short formats for time conversions

### DIFF
--- a/entity/date.go
+++ b/entity/date.go
@@ -21,6 +21,12 @@ func NewDate(tm time.Time) Date {
 var timeTemplate = []string{
 	time.RFC3339,
 	"2006-01T",
+	"2006-01-02",
+	"2006-01",
+	"2006/01/02",
+	"2006/01",
+	"2006",
+	"2006T",
 }
 
 //UnmarshalJSON returns result of Unmarshal for json.Unmarshal()


### PR DESCRIPTION
Added additional short formats for time conversions, due to some occasional error while parsing (e.g. B00UHQ73NO).

Admittedly, this might be an edge case, though.