### PR TITLE
`DiscountPercent` data type to json.Number

### DIFF
--- a/entity/entity.go
+++ b/entity/entity.go
@@ -212,7 +212,7 @@ type Item struct {
 			Promotions *[]struct {
 				Amount          float64
 				Currency        string
-				DiscountPercent string
+				DiscountPercent json.Number
 				DisplayAmount   string
 				PricePerUnit    float64
 				Type            string


### PR DESCRIPTION
When using this library we found that Amazon sometimes sends back a Number value for DiscountPercent and sometimes a String. 
This change allows the Parser to handle both